### PR TITLE
Add support for a slide querystring argument

### DIFF
--- a/src/slick.js
+++ b/src/slick.js
@@ -13,6 +13,7 @@
             end: undefined,
             keyControl: true,
             content: undefined,
+            slide_arg: undefined,
             theme: {
                 container: container,
                 content: '.slick-content',
@@ -85,10 +86,11 @@
         setSlide: function(step){
             var slick = this;
             var slideStatus = slick.hooks.slideStatus.apply(slick, [step]);
+            var slickContainer = $(slick.options.theme.container);
             slick.state.slide.current = step - slick.state.slide.difference;
 
-            if(slick.state.slide.current === 1){
-                $(slick.options.theme.container).animate({'opacity': '1'}, 500);
+            if (parseInt(slickContainer.css("opacity"), 10) === 0) {
+                slickContainer.animate({'opacity': '1'}, 500);
             }
 
             if($(slick.options.theme.container + ' .skip' + slick.options.theme.currentNo).is(':input')){
@@ -175,7 +177,7 @@
             if($.isNumeric(val)){
                 var slick = this;
 
-                var step = parseInt(val) + slick.state.slide.difference;
+                var step = parseInt(val, 10) + slick.state.slide.difference;
                 slick.hooks.getSlide.apply(slick, [step]);
                 slick.hooks.setSlide.apply(slick, [step]);
             }
@@ -188,12 +190,24 @@
 
         $(slick.options.theme.container).css('opacity', '0');
 
+        var getParameterByName = function (name) {
+            name = name.replace(/[\[]/, "\\[").replace(/[\]]/, "\\]");
+            var regex = new RegExp("[\\?&]" + name + "=([^&#]*)"),
+                results = regex.exec(location.search);
+            return results === null ? "" : decodeURIComponent(results[1].replace(/\+/g, " "));
+        };
+
         // Sets the first slide
-        if(typeof slick.options.source === 'string'){
-            slick.hooks.next.apply(slick);
-        }
-        else if (typeof(slick.options.source) == 'object' && slick.options.source !== null) {
-            slick.hooks.setSlide.apply(slick, [0]);
+        var slide_id = Math.max(parseInt(slick.options.start, 10), parseInt(getParameterByName(slick.options.slide_arg), 10));
+        if (isNaN(slide_id) || slide_id === 0) {
+            if (typeof slick.options.source === 'string') {
+                slick.hooks.next.apply(slick);
+            } else if (typeof(slick.options.source) == 'object' && slick.options.source !== null) {
+                slick.hooks.setSlide.apply(slick, [0]);
+            }
+        } else {
+            slide_id = Math.min(parseInt(slick.options.end, 10), slide_id);
+            slick.hooks.setSlide.apply(slick, [slide_id]);
         }
 
         // Attaches event listeners for next/prev buttons


### PR DESCRIPTION
This commit handles setting an optional `slide_arg` option. If set, the query-string value mapping to this key is retrieved and used to seed the first slide shown.

The change also properly handles setting the slide to a negative number, or a number larger than the number of slides by checking against the start and end option bounds. 

Note that we have to animate the container in because otherwise setting a non-0 slide as the current slide would produce a container that was hidden, even though there are contents.
